### PR TITLE
gtin.yaml fix

### DIFF
--- a/gtin-program-example/gtin.yaml
+++ b/gtin-program-example/gtin.yaml
@@ -1,6 +1,6 @@
 name: gtin_example
 version: '1.0'
-wasm: processor/target/wasm32-unknown-unknown/release/gtin_example.wasm
+wasm: processor/target/wasm32-unknown-unknown/release/gtin-example.wasm
 inputs:
   - '123456'
 outputs:


### PR DESCRIPTION
yaml referred to gtin_example.wasm, but what actually gets compiled is gtin-example.wasm; addresses file not found issue